### PR TITLE
Respect xCloud title entitlements

### DIFF
--- a/packages/desktop/main/helpers/titlemanager.ts
+++ b/packages/desktop/main/helpers/titlemanager.ts
@@ -19,6 +19,7 @@ interface titleInfoArgs {
 
 interface FilterArgs {
     name: string;
+    showNonEntitled?: boolean;
 }
 
 export default class TitleManager {
@@ -155,6 +156,8 @@ export default class TitleManager {
 
         for(const title in this._xCloudTitles){
             if(this._xCloudTitles[title].catalogDetails !== undefined){
+                if(filter.showNonEntitled === false && this._xCloudTitles[title].hasEntitlement === false)
+                    continue
 
                 if(this._xCloudTitles[title].catalogDetails.ProductTitle.toLowerCase().includes(filter.name.toLowerCase())){
                     returnTitles.push(this._xCloudTitles[title].titleId)
@@ -189,6 +192,7 @@ export class Title {
     titleId
     productId
     xboxTitleId
+    hasEntitlement
     supportedInputTypes
     catalogDetails
 
@@ -196,6 +200,7 @@ export class Title {
         this.titleId = title.titleId
         this.productId = title.details.productId
         this.xboxTitleId = title.details.xboxTitleId
+        this.hasEntitlement = title.details.hasEntitlement
         this.supportedInputTypes = title.details.supportedInputTypes
     }
 

--- a/packages/desktop/main/ipc/base.ts
+++ b/packages/desktop/main/ipc/base.ts
@@ -26,11 +26,15 @@ export default class IpcBase {
                 })
             }).catch((error) => {
                 console.log('ERROR: IPC communication error from backend:', error)
+                const serializedError = error instanceof Error ? {
+                    name: error.name,
+                    message: error.message,
+                } : error
                 this.send(channel, {
                     action: args.action,
                     id: args.id,
                     data: {},
-                    error: error,
+                    error: serializedError,
                 })
             })
 

--- a/packages/desktop/main/ipc/streaming.ts
+++ b/packages/desktop/main/ipc/streaming.ts
@@ -41,6 +41,12 @@ export default class IpcStreaming extends IpcBase {
         if(args.type === 'home'){
             this._application._ipc._channels.consoles._consolesLastUpdate = 0
         } else {
+            const title = this._application._ipc._channels.xCloud._titleManager.findTitle(args.target)
+            if(title?.hasEntitlement === false){
+                const error = new Error('User is not entitled to stream this title')
+                error.name = 'NoEntitlement'
+                return Promise.reject(error)
+            }
             this._application._ipc._channels.xCloud._recentTitlesLastUpdate = 0
         }
 

--- a/packages/desktop/main/ipc/xcloud.ts
+++ b/packages/desktop/main/ipc/xcloud.ts
@@ -6,6 +6,10 @@ interface getTitleArgs {
     titleId: string;
 }
 
+interface TitleListArgs {
+    showNonEntitled?: boolean;
+}
+
 export default class IpcxCloud extends IpcBase {
 
     _titleManager:TitleManager
@@ -13,6 +17,7 @@ export default class IpcxCloud extends IpcBase {
     _titlesAreLoaded = false
 
     _titles = []
+    _nonEntitledTitles = []
     _titlesLastUpdate = 0
 
     _recentTitles = []
@@ -85,32 +90,43 @@ export default class IpcxCloud extends IpcBase {
         })
     }
 
-    getTitles(){
+    getTitles(args:TitleListArgs = {}){
         return new Promise((resolve, reject) => {
             if(this._recentTitlesLastUpdate < Date.now() - 3600*1000){
                 this._application._xCloudApi.getTitles().then((titles:any) => {
                     const returnTitles = []
+                    const nonEntitledTitles = []
                     console.log('titles:', titles)
 
                     for(const title in titles.results){
-                        if(titles.results[title].titleId)
+                        if(titles.results[title].titleId){
                             returnTitles.push(titles.results[title].titleId)
-                        else
+                            if(titles.results[title].details?.hasEntitlement === false)
+                                nonEntitledTitles.push(titles.results[title].titleId)
+                        } else
                             this._application.log('Ipc:xCloud', 'Title found without a titleID:', titles.results[title])
                     }
 
                     this._titles = returnTitles
+                    this._nonEntitledTitles = nonEntitledTitles
                     this._titlesLastUpdate = Date.now()
 
-                    resolve(returnTitles)
+                    resolve(this.filterTitlesByEntitlement(returnTitles, args.showNonEntitled))
                 })
                     .catch((error) => {
                         reject(error)
                     })
             } else {
-                resolve(this._titles)
+                resolve(this.filterTitlesByEntitlement(this._titles, args.showNonEntitled))
             }
         })
+    }
+
+    filterTitlesByEntitlement(titles, showNonEntitled = true){
+        if(showNonEntitled)
+            return titles
+
+        return titles.filter((titleId) => !this._nonEntitledTitles.includes(titleId))
     }
 
     filterTitles(filter){
@@ -121,7 +137,7 @@ export default class IpcxCloud extends IpcBase {
         })
     }
 
-    getNewTitles(){
+    getNewTitles(args:TitleListArgs = {}){
         return new Promise((resolve, reject) => {
             if(this._newTitlesLastUpdate < Date.now() - 3600*1000){
                 this._titleManager.getNewTitles().then((titles:any) => {
@@ -145,12 +161,12 @@ export default class IpcxCloud extends IpcBase {
                     this._newTitles = returnTitles
                     this._newTitlesLastUpdate = Date.now()
 
-                    resolve(returnTitles)
+                    resolve(this.filterTitlesByEntitlement(returnTitles, args.showNonEntitled))
                 }).catch((error) => {
                     reject(error)
                 })
             } else {
-                resolve(this._newTitles)
+                resolve(this.filterTitlesByEntitlement(this._newTitles, args.showNonEntitled))
             }
         })
     }

--- a/packages/desktop/renderer/components/ui/game/title.css
+++ b/packages/desktop/renderer/components/ui/game/title.css
@@ -3,6 +3,16 @@ div.component_gametitle {
     width: 140px;
 }
 
+div.component_gametitle_unentitled img {
+    filter: grayscale(1);
+    opacity: 0.45;
+    transition: opacity 0.2s ease-in-out;
+}
+
+div.component_gametitle_unentitled:hover img {
+    opacity: 0.65;
+}
+
 div.component_gametitle div.component_gametitle_title {
     background: #000000;
     background: linear-gradient(0deg, rgba(0,135,70,0.5) 50%, rgba(0,0,0,0) 100%);

--- a/packages/desktop/renderer/components/ui/game/titledynamic.tsx
+++ b/packages/desktop/renderer/components/ui/game/titledynamic.tsx
@@ -12,6 +12,7 @@ interface GameTitleProps {
 
 interface titleDataState {
     titleId?: string;
+    hasEntitlement?: boolean;
     catalogDetails?: {
         ProductTitle: string;
         Image_Tile: {
@@ -28,12 +29,12 @@ function GameTitleDynamic({
 
     return (
         <React.Fragment>
-            <div className='component_gametitle'>
+            <div className={ `component_gametitle${titleData.data?.hasEntitlement === false ? ' component_gametitle_unentitled' : ''}` }>
                 <div className='component_gametitle_infopage'>
                     <Link href={ '/xcloud/info/'+titleId } title={t("page.xCloudLibrary.viewGamePageIcon")}><i className="fa-solid fa-info" /></Link>
                 </div>
 
-                { (titleData.isFetched === true && titleData.data.titleId !== undefined) ? <Link href={ `/stream/xcloud_${ titleId }` }>
+                { (titleData.isFetched === true && titleData.data.titleId !== undefined) ? <Link href={ titleData.data.hasEntitlement === false ? `/xcloud/info/${ titleId }` : `/stream/xcloud_${ titleId }` }>
 
                     <Image
                         src={ 'https:'+titleData.data.catalogDetails.Image_Tile?.URL }

--- a/packages/desktop/renderer/context/userContext.defaults.ts
+++ b/packages/desktop/renderer/context/userContext.defaults.ts
@@ -1,6 +1,7 @@
 export const defaultSettings = {
     xhome_bitrate: 0,
     xcloud_bitrate: 0,
+    xcloud_show_non_entitled: true,
     video_profiles: [],
     preferred_game_language: 'en-US',
     controller_vibration: true,

--- a/packages/desktop/renderer/languages/Greenlight_Spanish.json
+++ b/packages/desktop/renderer/languages/Greenlight_Spanish.json
@@ -85,6 +85,7 @@
         "description": "Por defecto, xHome y xCloud no admiten más de 20 mbps. Este ajuste no anula el límite.",
         "xCloudStreamingBitrateLabel": "Tasa de bits (Bitrate) de xCloud",
         "xHomeStreamingBitrateLabel": "Tasa de bits (Bitrate) de xHome",
+        "showNonEntitledLabel": "Mostrar juegos que requieren compra",
         "unlimitedLabel": "Ilimitado / Desactivado",
         "mbpsLabel": "mbps",
         "setH264ProfileLabel": "Configurar perfil H.264",
@@ -198,7 +199,8 @@
         "by": "de",
         "descriptionTitle": "Descripción",
         "capabilitiesTitle": "Características",
-        "startStreamBtn": "Iniciar streaming"
+        "startStreamBtn": "Iniciar streaming",
+        "purchaseRequiredBtn": "Compra requerida"
       },
       "page404": {
         "pageTitle": "Error",

--- a/packages/desktop/renderer/languages/de-DE.json
+++ b/packages/desktop/renderer/languages/de-DE.json
@@ -85,6 +85,7 @@
         "description": "xHome und xCloud unterstützen standardmäßig nicht mehr als 20 Mbps. Diese Einstellung hebt das Limit nicht auf.",
         "xCloudStreamingBitrateLabel": "xCloud Streamingbitrate",
         "xHomeStreamingBitrateLabel": "xHome Streamingbitrate",
+        "showNonEntitledLabel": "Spiele anzeigen, für die ein Kauf erforderlich ist",
         "unlimitedLabel": "Unbegrenzt / Aus",
         "mbpsLabel": "Mbps",
         "setH264ProfileLabel": "Lege H.264-Profil fest",
@@ -198,7 +199,8 @@
         "by": "von",
         "descriptionTitle": "Beschreibung",
         "capabilitiesTitle": "Fähigkeiten",
-        "startStreamBtn": "Starte Stream"
+        "startStreamBtn": "Starte Stream",
+        "purchaseRequiredBtn": "Kauf erforderlich"
       },
       "page404": {
         "pageTitle": "Fehler",

--- a/packages/desktop/renderer/languages/en-US.json
+++ b/packages/desktop/renderer/languages/en-US.json
@@ -90,6 +90,7 @@
         "description": "xHome and xCloud do not support more than 20mbps by default. This setting does not override this limit.",
         "xCloudStreamingBitrateLabel": "xCloud Streaming Bitrate",
         "xHomeStreamingBitrateLabel": "xHome Streaming Bitrate",
+        "showNonEntitledLabel": "Show games that require purchase",
         "unlimitedLabel": "Unlimited / Off",
         "mbpsLabel": "mbps",
         "setH264ProfileLabel": "Set H.264 Profile",
@@ -209,7 +210,8 @@
         "by": "by",
         "descriptionTitle": "Description",
         "capabilitiesTitle": "Capabilities",
-        "startStreamBtn": "Start Stream"
+        "startStreamBtn": "Start Stream",
+        "purchaseRequiredBtn": "Purchase required"
       },
 
       "page404": {

--- a/packages/desktop/renderer/languages/ru-RU.json
+++ b/packages/desktop/renderer/languages/ru-RU.json
@@ -90,6 +90,7 @@
         "description": "xHome и xCloud по умолчанию не поддерживают более 20 Мбит/с. Эта настройка не отменяет это ограничение.",
         "xCloudStreamingBitrateLabel": "Битрейт трансляции xCloud",
         "xHomeStreamingBitrateLabel": "Битрейт трансляции xHome",
+        "showNonEntitledLabel": "Показывать игры, требующие покупки",
         "unlimitedLabel": "Без ограничений / Выкл.",
         "mbpsLabel": "Мбит/с",
         "setH264ProfileLabel": "Установить профиль H.264",
@@ -209,7 +210,8 @@
         "by": "От",
         "descriptionTitle": "Описание",
         "capabilitiesTitle": "Возможности",
-        "startStreamBtn": "Начать трансляцию"
+        "startStreamBtn": "Начать трансляцию",
+        "purchaseRequiredBtn": "Требуется покупка"
       },
 
       "page404": {

--- a/packages/desktop/renderer/languages/uk-UA.json
+++ b/packages/desktop/renderer/languages/uk-UA.json
@@ -90,6 +90,7 @@
         "description": "xHome і xCloud за замовчуванням не підтримують більше 20 Мбіт/с. Ця настройка не скасовує це обмеження.",
         "xCloudStreamingBitrateLabel": "Бітрейт трансляції xCloud",
         "xHomeStreamingBitrateLabel": "Бітрейт трансляції xHome",
+        "showNonEntitledLabel": "Показувати ігри, які потрібно придбати",
         "unlimitedLabel": "Без обмежень / Викл.",
         "mbpsLabel": "Мбіт/с",
         "setH264ProfileLabel": "Встановити профіль H.264",
@@ -209,7 +210,8 @@
         "by": "Від",
         "descriptionTitle": "Опис",
         "capabilitiesTitle": "Можливості",
-        "startStreamBtn": "Почати трансляцію"
+        "startStreamBtn": "Почати трансляцію",
+        "purchaseRequiredBtn": "Потрібна покупка"
       },
 
       "page404": {

--- a/packages/desktop/renderer/pages/settings/streaming.tsx
+++ b/packages/desktop/renderer/pages/settings/streaming.tsx
@@ -34,6 +34,13 @@ function SettingsStreaming() {
         })
     }
 
+    function setShowNonEntitled(e){
+        setSettings({
+            ...settings,
+            xcloud_show_non_entitled: e.target.checked,
+        })
+    }
+
     function setVideoProfile(profile){
         console.log('Set video profile to:', profile)
         setSettings({
@@ -87,6 +94,11 @@ function SettingsStreaming() {
                         <label>{t('settings.streaming.xHomeStreamingBitrateLabel')}</label>
                         <input type="range" min="0" max="40960" step="1024" value={settings.xhome_bitrate} onChange={ setxHomeBitrate } />
                 ({ settings.xhome_bitrate === 0 ? t('settings.streaming.unlimitedLabel') : Math.floor(settings.xhome_bitrate / 1024) + ' ' + t('settings.streaming.mbpsLabel') })
+                    </p>
+
+                    <p>
+                        <label>{t('settings.streaming.showNonEntitledLabel')}</label>
+                        <input type='checkbox' checked={settings.xcloud_show_non_entitled} onChange={setShowNonEntitled} />
                     </p>
 
                     <p>

--- a/packages/desktop/renderer/pages/xcloud/home.tsx
+++ b/packages/desktop/renderer/pages/xcloud/home.tsx
@@ -7,11 +7,13 @@ import BreadcrumbBar from '../../components/ui/breadcrumbbar'
 import TitleRow from '../../components/xcloud/titleRow'
 import { useQuery } from 'react-query'
 import { useTranslation } from 'react-i18next'
+import { useSettings } from '../../context/userContext'
 
 function xCloudHome() {
     const { t } = useTranslation()
-    useQuery('xCloudTitles', () => Ipc.send('xCloud', 'getTitles'), { staleTime: 300*1000 })
-    const xCloudNewTitles = useQuery('xCloudNewTitles', () => Ipc.send('xCloud', 'getNewTitles'), { staleTime: 60*1000 })
+    const { settings } = useSettings()
+    useQuery(['xCloudTitles', settings.xcloud_show_non_entitled], () => Ipc.send('xCloud', 'getTitles', { showNonEntitled: settings.xcloud_show_non_entitled }), { staleTime: 300*1000 })
+    const xCloudNewTitles = useQuery(['xCloudNewTitles', settings.xcloud_show_non_entitled], () => Ipc.send('xCloud', 'getNewTitles', { showNonEntitled: settings.xcloud_show_non_entitled }), { staleTime: 60*1000 })
     const xCloudRecentTitles = useQuery('xCloudRecentTitles', () => Ipc.send('xCloud', 'getRecentTitles'), { staleTime: 10*1000 })
 
     return (

--- a/packages/desktop/renderer/pages/xcloud/info/[titleid].tsx
+++ b/packages/desktop/renderer/pages/xcloud/info/[titleid].tsx
@@ -17,6 +17,7 @@ function xCloudInfo() {
     const productDetails = useQuery('xcloudinfo_titleId_'+router.query.titleid, () => Ipc.send('xCloud', 'getTitle', { titleId: router.query.titleid}), { staleTime: 10*1000 })
     const [productName, setProductName] = React.useState('...')
     const { t } = useTranslation()
+    const hasEntitlement = productDetails.data?.hasEntitlement !== false
 
     if(productDetails.isFetched === true && productName === '...')
         setProductName(productDetails.data.catalogDetails.ProductTitle)
@@ -52,9 +53,9 @@ function xCloudInfo() {
                         <Image src={ 'https:'+productDetails.data.catalogDetails.Image_Poster?.URL } alt={productName} width={ 640/4 } height={ 960/4 } /><br />
                         <br />
 
-                        <Link href={ '/stream/xcloud_'+router.query.titleid }>
+                        {hasEntitlement ? <Link href={ '/stream/xcloud_'+router.query.titleid }>
                             <Button label={ t('page.titleInfo.startStreamBtn') } className='btn-primary'></Button>
-                        </Link>
+                        </Link> : <Button label={ t('page.titleInfo.purchaseRequiredBtn') } className='btn-primary' disabled={true}></Button>}
                     </div>
 
                     <div id="page_info_titleid_content">

--- a/packages/desktop/renderer/pages/xcloud/library.tsx
+++ b/packages/desktop/renderer/pages/xcloud/library.tsx
@@ -8,16 +8,18 @@ import GameTitleDynamic from '../../components/ui/game/titledynamic'
 import BreadcrumbBar from '../../components/ui/breadcrumbbar'
 import { useQuery, QueryClient } from 'react-query'
 import { useTranslation } from 'react-i18next'
+import { useSettings } from '../../context/userContext'
 
 
 function xCloudLibrary() {
     const { t } = useTranslation()
+    const { settings } = useSettings()
     const [filter, setFilter] = React.useState({
         name: '',
     })
 
-    const xCloudTitles = useQuery('xCloudTitles', () => Ipc.send('xCloud', 'getTitles'), { staleTime: 300*1000 })
-    const xCloudSearch = useQuery(['xCloudSearch', filter], () => Ipc.send('xCloud', 'filterTitles', filter))
+    const xCloudTitles = useQuery(['xCloudTitles', settings.xcloud_show_non_entitled], () => Ipc.send('xCloud', 'getTitles', { showNonEntitled: settings.xcloud_show_non_entitled }), { staleTime: 300*1000 })
+    const xCloudSearch = useQuery(['xCloudSearch', filter, settings.xcloud_show_non_entitled], () => Ipc.send('xCloud', 'filterTitles', { ...filter, showNonEntitled: settings.xcloud_show_non_entitled }))
     const queryClient = new QueryClient()
 
     function performFilter(){


### PR DESCRIPTION
Fixes #1514

## Cause

The authenticated /v2/titles response already includes details.hasEntitlement, but Greenlight declares the field in TitleDetails and then drops it when constructing its Title objects. As a result, both the library and title information page offer to start titles the signed-in user cannot play.

## Changes

- retain hasEntitlement from the existing title response; no additional API request is introduced
- grey out unentitled library tiles while keeping them visible by default
- add a persisted Streaming setting to show or hide games that require purchase
- apply the preference to the full library, searches, and recently-added titles
- route visible unentitled tiles to the information page instead of starting a stream
- replace the Stream button with a disabled, localized Purchase required button
- reject direct stream attempts for known-unentitled cloud titles before session creation
- add the new labels to English, German, Spanish, Russian, and Ukrainian translations

Undefined entitlement values remain playable for backwards compatibility; only an explicit false is blocked. The visibility setting defaults to enabled to preserve the current catalogue view.

## Validation

- yarn desktop lint (passes; generated Next.js output emits five pre-existing warnings after a build)
- yarn desktop build --no-pack (passes, including TypeScript and production renderer/main builds)